### PR TITLE
Enforce Connection: close for close-delimited responses in HTTP/1.1

### DIFF
--- a/luncheon/http_message.lua
+++ b/luncheon/http_message.lua
@@ -339,17 +339,20 @@ function HttpMessage:body_type()
 
   enc = headers:get_all("transfer_encoding")
   local ty = "close"
-  if not enc then
-    return {
-      type = ty,
-    }
-  end
-  for _, v in ipairs(enc) do
-    if HttpMessage.includes_chunk_encoding(v) then
-      ty = "chunked"
-      break
+  if enc then
+    for _, v in ipairs(enc) do
+      if HttpMessage.includes_chunk_encoding(v) then
+        ty = "chunked"
+        break
+      end
     end
   end
+
+  -- Check for protocol violation: close-delimited responses in HTTP/1.1 must have Connection: close
+  if ty == "close" and self.http_version and self.http_version >= 1.1 and self:get_connection() ~= "close" then
+    return nil, "Protocol violation: close-delimited response without Connection: close in HTTP/1.1"
+  end
+
   local trailers = false
   if ty == "chunked" then
     local trailer = headers:get_all("trailer")
@@ -519,6 +522,17 @@ function HttpMessage:get_headers()
     end
   end
   return self.headers
+end
+
+---@return string|nil
+---@return nil|string
+function HttpMessage:get_connection()
+  local headers, err = self:get_headers()
+  if not headers then
+    return nil, err
+  end
+  local connection = headers:get_one("connection")
+  return connection and string.lower(connection)
 end
 
 --- Serailize the provide Request or Response into a string with new lines


### PR DESCRIPTION
## Description

This PR addresses a potential hang issue in the Luncheon HTTP library when parsing responses that lack `Content-Length` or `Transfer-Encoding` headers on HTTP/1.1 keep-alive connections. The issue arises because the library correctly follows RFC 9112 by reading the response body until the connection closes, but non-compliant servers may not close keep-alive connections, leading to indefinite waits.

To resolve this, we enforce **RFC 9112 Section 9.6**, which states that servers MUST send `Connection: close` for any HTTP/1.1 message immediately followed by a connection close. Close-delimited responses (without explicit length indicators) inherently require the connection to close, so we now reject such responses if `Connection: close` is not present, preventing hangs on malformed servers.

This change improves robustness for embedded systems like SmartThings hubs while maintaining spec compliance for well-behaved servers.

## Changes

- **Added `HttpMessage:get_connection()` method**: Retrieves and normalizes the `Connection` header value (lowercased), returning `nil` if absent.
- **Modified `HttpMessage:body_type()`**: 
  - Unified the logic to determine body type (`close` or `chunked`) without early returns.
  - Added a protocol violation check for HTTP/1.1 close-delimited responses: If `Connection` is not explicitly `close`, return an error instead of proceeding.
- **No breaking changes**: The fix only affects invalid responses; valid ones continue to work.

## Testing

- **Manual Testing**: Verified that responses with `Connection: close` and close-delimiting work as before.
- **Error Cases**: Confirmed that responses without `Connection: close` (or with `keep-alive`) now fail fast with a clear error message.
- **Regression**: Existing tests should pass; no functional changes for compliant responses.

## Related Issues

- Fixes the hang described in the SmartThings community thread: [Luncheon Response Bug API 16](https://community.smartthings.com/t/luncheon-response-bug-api-16/308321)
- Enforces RFC 9112 Section 9.6 for better protocol adherence.

## Checklist

- [x] Code follows existing style and conventions.
- [x] Error messages are clear and actionable.
- [x] No performance impact on valid responses.
- [x] Tested with edge cases (no headers, various connection values).